### PR TITLE
Rename __initialize method.

### DIFF
--- a/d2l-menu-item-behavior.html
+++ b/d2l-menu-item-behavior.html
@@ -35,13 +35,13 @@
 		__children: null,
 
 		ready: function() {
-			this.__initialize();
+			this.__initializeItem();
 		},
 
 		attached: function() {
 
 			Polymer.RenderStatus.afterNextRender(this, function() {
-				Polymer.dom(this).observeNodes(this.__initialize);
+				Polymer.dom(this).observeNodes(this.__initializeItem);
 
 				this.listen(this, 'blur', '__onBlur');
 				this.listen(this, 'click', '__onClick');
@@ -66,7 +66,7 @@
 			this.unlisten(this, 'mouseleave', '__onMouseLeave');
 		},
 
-		__initialize: function() {
+		__initializeItem: function() {
 			var children = this.getEffectiveChildren();
 			if (children && children.length > 0 && children[0].tagName === 'TEMPLATE') {
 				return;
@@ -111,7 +111,7 @@
 		},
 
 		__onDomChange: function() {
-			this.__initialize();
+			this.__initializeItem();
 		},
 
 		__onFocus: function() {


### PR DESCRIPTION
Rename `__initialize` method so that it doesn't collide with method of same name introduced in Polymer 1.8.0.