### PR TITLE
Update d2l-menu-item-link to support target.

### DIFF
--- a/d2l-menu-item-link.html
+++ b/d2l-menu-item-link.html
@@ -63,7 +63,7 @@
 				}
 			},
 
-			_onSelect: function(e) {
+			_onSelect: function() {
 				if (!this.preventDefault) {
 					if (this.target === '_parent') {
 						window.parent.location.assign(this.href);

--- a/d2l-menu-item-link.html
+++ b/d2l-menu-item-link.html
@@ -25,7 +25,7 @@
 			}
 
 		</style>
-		<a href$="[[href]]" tabindex="-1">[[text]]</a>
+		<a href$="[[href]]" target$=[[target]] tabindex="-1">[[text]]</a>
 	</template>
 
 	<script>
@@ -41,7 +41,8 @@
 				preventDefault: {
 					type: Boolean,
 					reflectToAttribute: true
-				}
+				},
+				target: String
 			},
 
 			attached: function() {
@@ -63,8 +64,14 @@
 			},
 
 			_onSelect: function(e) {
-				if ((Polymer.dom(e).rootTarget !== this.$$('a')) && !this.preventDefault) {
-					window.location.assign(this.href);
+				if (!this.preventDefault) {
+					if (this.target === '_parent') {
+						window.parent.location.assign(this.href);
+					} else if (this.target === '_top') {
+						window.top.location.assign(this.href);
+					} else {
+						window.location.assign(this.href);
+					}
 				}
 			}
 


### PR DESCRIPTION
This change updates `d2l-menu-item-link` to support `target` attribute.  It addresses a couple of issues:

* activating link via keyboard should honor target (as opposed to simply going `window.loacation.assign`)
* safari oddly hangs if anchor is clicked (causing navigation of parent, and also window location is assigned differently