### PR TITLE
Dbatiste/fix double navigation

### DIFF
--- a/d2l-menu-item-link.html
+++ b/d2l-menu-item-link.html
@@ -63,8 +63,8 @@
 				}
 				var base = document.getElementsByTagName('base');
 				if (base && base.length > 0) {
-						base = base[0];
-						return base.getAttribute('target');
+					base = base[0];
+					return base.getAttribute('target');
 				}
 				return null;
 			},

--- a/d2l-menu-item-link.html
+++ b/d2l-menu-item-link.html
@@ -47,14 +47,26 @@
 
 			attached: function() {
 				Polymer.RenderStatus.afterNextRender(this, function() {
-					this.listen(this, 'd2l-menu-item-select', '_onSelect');
+					this.listen(this, 'keydown', '_onKeyDown');
 					this.listen(this.$$('a'), 'click', '_onClick');
 				}.bind(this));
 			},
 
 			detached: function() {
-				this.unlisten(this, 'd2l-menu-item-select', '_onSelect');
+				this.unlisten(this, 'keydown', '_onKeyDown');
 				this.unlisten(this.$$('a'), 'click', '_onClick');
+			},
+
+			_getTarget: function() {
+				if (this.target && this.target !== '') {
+					return this.target;
+				}
+				var base = document.getElementsByTagName('base');
+				if (base && base.length > 0) {
+						base = base[0];
+						return base.getAttribute('target');
+				}
+				return null;
 			},
 
 			_onClick: function(e) {
@@ -63,11 +75,16 @@
 				}
 			},
 
-			_onSelect: function() {
-				if (!this.preventDefault) {
-					if (this.target === '_parent') {
+			_onKeyDown: function(e) {
+				if (this.preventDefault) {
+					e.preventDefault();
+					return;
+				}
+				if (e.keyCode === this.__keyCodes.ENTER || e.keyCode === this.__keyCodes.SPACE) {
+					var target = this._getTarget();
+					if (target === '_parent') {
 						window.parent.location.assign(this.href);
-					} else if (this.target === '_top') {
+					} else if (target === '_top') {
 						window.top.location.assign(this.href);
 					} else {
 						window.location.assign(this.href);


### PR DESCRIPTION
This change updates `d2l-menu-item-link` to prevent possible double navigation that has potential to lock up Safari (specifically, when anchor navigation starts while honoring base target attribute, then JS navigation is triggers ignoring target).

This change also adds support for base target attribute when navigating as a result of keyboard.
