### PR TITLE
Add rtl style for the icon of selectable menu items

### DIFF
--- a/d2l-menu-item-selectable-styles.html
+++ b/d2l-menu-item-selectable-styles.html
@@ -34,6 +34,16 @@
 				margin-right: 0.8rem;
 			}
 
+			:host-context([dir="rtl"]) > d2l-icon {
+				margin-left: 0.8rem;
+				margin-right: 0;
+			}
+
+			:host(:dir(rtl)) > d2l-icon {
+				margin-left: 0.8rem;
+				margin-right: 0;
+			}
+
 			:host([aria-checked="true"]) > d2l-icon {
 				visibility: visible;
 			}


### PR DESCRIPTION
Noticed this when testing with `rtl`:

Before:
<img width="646" alt="screen shot 2018-11-01 at 10 48 11 am" src="https://user-images.githubusercontent.com/6110668/47865210-fac64000-ddd1-11e8-9ef0-37d346d1fcf0.png">

---
After
<img width="644" alt="screen shot 2018-11-01 at 10 49 23 am" src="https://user-images.githubusercontent.com/6110668/47865211-fac64000-ddd1-11e8-9c2a-c3e443010461.png">
