### PR TITLE
change how returnItem is removed

### DIFF
--- a/d2l-menu.html
+++ b/d2l-menu.html
@@ -158,13 +158,14 @@ Polymer-based web component for menus.
 				this.active = this.getActiveView() === this;
 
 				var returnItem = this.$$('d2l-menu-item-return');
+				var items = this.$$('.d2l-menu-items');
 				if (!this.childView && returnItem) {
 
-					Polymer.dom(this.root).removeChild(returnItem);
+					Polymer.dom(items).removeChild(returnItem);
+					this._onMenuItemsChanged();
 
 				} else if (this.childView && !returnItem) {
 
-					var items = this.$$('.d2l-menu-items');
 					requestAnimationFrame(function() {
 						Polymer.dom(items).insertBefore(
 							this._createReturnItem(),


### PR DESCRIPTION
In button-group, when a dropdown menu was added to another dropdown menu (through shrinking the window), then removed (through enlarging the window), this was failing with the error `The node to be removed is not a child of this node.`, since with shadow dom it's no longer a direct child of `d2l-menu`. Related to this PR https://github.com/BrightspaceUI/button-group/pull/58