### PR TITLE
US108242: d2l-dropdown/menu accessibility issues

### DIFF
--- a/d2l-menu.js
+++ b/d2l-menu.js
@@ -264,7 +264,9 @@ Polymer({
 	},
 
 	_labelChanged: function(newValue) {
-		this.setAttribute('aria-label', newValue);
+		if (newValue) {
+			this.setAttribute('aria-label', newValue);
+		}
 		var returnItem = this.$$('d2l-menu-item-return');
 		if (returnItem) {
 			dom(returnItem).setAttribute('text', newValue);

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "polymer-cli": "^1.9.9",
     "wct-browser-legacy": "^1.0.1"
   },
-  "version": "2.3.2",
+  "version": "2.3.3",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "polymer-cli": "^1.9.9",
     "wct-browser-legacy": "^1.0.1"
   },
-  "version": "2.3.3",
+  "version": "2.3.2",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",


### PR DESCRIPTION
d2l-menu accessibility issue: when used with d2l-dropdown, this.label is not properly assigned, and then aria-label being set to null. Therefore the screen reader says "menu undefined x" instead of "menu x", where x is the number of items in that menu.