### PR TITLE
core 1.7.1 or higher is required

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "main": "d2l-menu.js",
   "dependencies": {
-    "@brightspace-ui/core": "^1",
+    "@brightspace-ui/core": "^1.7.1",
     "@polymer/polymer": "^3.0.0",
     "d2l-colors": "BrightspaceUI/colors#semver:^4",
     "d2l-hierarchical-view": "BrightspaceUI/hierarchical-view#semver:^2",


### PR DESCRIPTION
That was when `requestIdleCallback` was added to core.